### PR TITLE
Update styling of Add/Edit Objective dialog

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -57,7 +57,6 @@ import { LoginComponent } from './login/login.component';
 import { NotificationService } from './services/notification.service';
 import { AuthInterceptor } from './services/auth.interceptor';
 import { firebaseConfig } from '../environments/firebaseConfig';
-import { MAT_SNACK_BAR_DEFAULT_OPTIONS } from '@angular/material/snack-bar';
 import { ModalComponent } from './modal/modal.component';
 import { DisplayObjectivesPipe } from './bucket/displayobjectives.pipe';
 import { CsumClassPipe } from './objective/csum-class.pipe';
@@ -118,10 +117,6 @@ import { MarkdownifyPipe } from './markdown/markdownify.pipe';
       provide: HTTP_INTERCEPTORS,
       useClass: AuthInterceptor,
       multi: true,
-    },
-    {
-      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
-      useValue: { duration: 2500 },
     },
   ],
   bootstrap: [AppComponent],

--- a/src/app/edit-objective-dialog/edit-objective-dialog.component.css
+++ b/src/app/edit-objective-dialog/edit-objective-dialog.component.css
@@ -1,5 +1,30 @@
-.dialog-content {
+app-edit-objective-dialog .dialog-content {
+  align-items: flex-start;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+}
+
+app-edit-objective-dialog mat-form-field {
+  width: 320px;
+}
+
+app-edit-objective-dialog mat-form-field[ng-reflect-hint-label] {
+  margin-bottom: 16px;
+}
+
+app-edit-objective-dialog .mat-checkbox {
+  align-items: center;
+  display: inline-flex;
+  min-height: 40px; /* The ripple is 40px so this needs to be bigger */
+}
+
+app-edit-objective-dialog .mat-checkbox-inner-container {
+  margin-right: 12px; /* Need clearance so ripple doesn't overlap with text */
+}
+
+app-edit-objective-dialog .mat-icon-button .mat-button-wrapper {
+  align-items: center;
+  display: flex;
+  height: 40px;
+  justify-content: center;
 }

--- a/src/app/edit-objective-dialog/edit-objective-dialog.component.css
+++ b/src/app/edit-objective-dialog/edit-objective-dialog.component.css
@@ -1,15 +1,44 @@
-app-edit-objective-dialog .dialog-content {
-  align-items: flex-start;
-  display: flex;
-  flex-direction: column;
+app-edit-objective-dialog fieldset {
+  --gap: 32px;
+  --normal: 320px;
+  --wide: 640px;
+  border: 0;
+  column-gap: var(--gap);
+  display: grid;
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
 }
 
-app-edit-objective-dialog mat-form-field {
-  width: 320px;
+app-edit-objective-dialog fieldset:first-of-type {
+  grid-template-columns: minmax(min-content, var(--wide)) 1fr;
+}
+
+app-edit-objective-dialog fieldset:nth-of-type(2) {
+  --resource: 109px; /* The smallest possible width for 'Resource estimate' */
+  /*
+   * Dynamically calculate the width of 'Commitment type' so that it's the right
+   * size so that the 'Objective' field and 'Groups' field line up perfectly
+   */
+  --commitment: calc(
+    var(--wide) - var(--normal) - var(--resource) - 2 * var(--gap)
+  );
+  grid-template-columns: minmax(136px, var(--commitment)) var(--resource) repeat(
+      2,
+      minmax(min-content, var(--normal))
+    );
 }
 
 app-edit-objective-dialog mat-form-field[ng-reflect-hint-label] {
   margin-bottom: 16px;
+}
+
+app-edit-objective-dialog .markdown {
+  align-content: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, min-content);
+  padding-bottom: 1.34375em; /* Same as .mat-form-field-wrapper */
 }
 
 app-edit-objective-dialog .mat-checkbox {
@@ -27,4 +56,19 @@ app-edit-objective-dialog .mat-icon-button .mat-button-wrapper {
   display: flex;
   height: 40px;
   justify-content: center;
+}
+
+@media (max-width: 958px) {
+  app-edit-objective-dialog fieldset:nth-of-type(2) {
+    /* Split the 2nd fieldset into two columns only */
+    grid-template-columns: repeat(2, minmax(min-content, 1fr));
+  }
+}
+
+@media (max-width: 602px) {
+  app-edit-objective-dialog .mat-dialog-content fieldset {
+    /* Put everything into one column */
+    grid-template-columns: 1fr;
+    padding: 0;
+  }
 }

--- a/src/app/edit-objective-dialog/edit-objective-dialog.component.html
+++ b/src/app/edit-objective-dialog/edit-objective-dialog.component.html
@@ -9,8 +9,8 @@
     Preview:
     <p [innerHTML]="data.objective.name | markdownify"></p>
   </div>
-  <mat-form-field appearance="fill">
-    <mat-label>Resource estimate ({{data.unit}})</mat-label>
+  <mat-form-field hintLabel="({{data.unit}})" appearance="fill">
+    <mat-label>Resource estimate</mat-label>
     <input matInput [(ngModel)]="data.objective.resourceEstimate" type="number">
   </mat-form-field>
   <mat-form-field appearance="fill">
@@ -20,19 +20,30 @@
         <mat-option value="Committed">Committed</mat-option>
     </mat-select>
   </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Groups (key1:value1,key2:value2,...)</mat-label>
+  <mat-form-field hintLabel="(key1:value1,key2:value2,...)" appearance="fill">
+    <mat-label>Groups</mat-label>
     <input matInput [(ngModel)]="data.objective.groups">
   </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Tags (comma-separated)</mat-label>
+  <mat-form-field hintLabel="(Comma-separated)" appearance="fill">
+    <mat-label>Tags</mat-label>
     <input matInput [(ngModel)]="data.objective.tags">
   </mat-form-field>
   <mat-form-field appearance="fill">
     <mat-label>Notes</mat-label>
-    <textarea matInput [(ngModel)]="data.objective.notes"></textarea>
+    <textarea matInput [(ngModel)]="data.objective.notes" rows="3"></textarea>
   </mat-form-field>
-  <mat-checkbox [(ngModel)]="data.objective.displayOptions.enableMarkdown">Enable Markdown <a mat-button href="https://guides.github.com/features/mastering-markdown/#examples" target="_blank" rel="noopener noreferrer"><mat-icon>help_outline</mat-icon></a></mat-checkbox>
+  <div class="flex">
+    <mat-checkbox class="margin-right-8"
+        [(ngModel)]="data.objective.displayOptions.enableMarkdown">
+      Enable Markdown
+    </mat-checkbox>
+    <a mat-icon-button
+        href="https://guides.github.com/features/mastering-markdown/#examples"
+        target="_blank"
+        rel="noopener noreferrer">
+      <mat-icon>help_outline</mat-icon>
+    </a>
+  </div>
 </div>
 
 <div mat-dialog-actions>

--- a/src/app/edit-objective-dialog/edit-objective-dialog.component.html
+++ b/src/app/edit-objective-dialog/edit-objective-dialog.component.html
@@ -1,49 +1,54 @@
 <h1 mat-dialog-title>{{data.title}}</h1>
 
-<div mat-dialog-content class="dialog-content">
-  <mat-form-field appearance="fill">
-    <mat-label>Objective</mat-label>
-    <input matInput [(ngModel)]="data.objective.name">
-  </mat-form-field>
+<div mat-dialog-content>
+  <fieldset>
+    <mat-form-field appearance="fill">
+      <mat-label>Objective</mat-label>
+      <input matInput [(ngModel)]="data.objective.name">
+    </mat-form-field>
+    <div class="markdown">
+      <mat-checkbox [(ngModel)]="data.objective.displayOptions.enableMarkdown">
+        Enable Markdown
+      </mat-checkbox>
+      <a mat-icon-button
+          href="https://guides.github.com/features/mastering-markdown/#examples"
+          target="_blank"
+          rel="noopener noreferrer">
+        <mat-icon>help_outline</mat-icon>
+      </a>
+    </div>
+  </fieldset>
   <div *ngIf="data.objective.displayOptions.enableMarkdown" class="mat-form-field-wrapper">
     Preview:
     <p [innerHTML]="data.objective.name | markdownify"></p>
   </div>
-  <mat-form-field hintLabel="({{data.unit}})" appearance="fill">
-    <mat-label>Resource estimate</mat-label>
-    <input matInput [(ngModel)]="data.objective.resourceEstimate" type="number">
-  </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Commitment type</mat-label>
-    <mat-select [(ngModel)]="data.objective.commitmentType">
-        <mat-option value="Aspirational">Aspirational</mat-option>
-        <mat-option value="Committed">Committed</mat-option>
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field hintLabel="(key1:value1,key2:value2,...)" appearance="fill">
-    <mat-label>Groups</mat-label>
-    <input matInput [(ngModel)]="data.objective.groups">
-  </mat-form-field>
-  <mat-form-field hintLabel="(Comma-separated)" appearance="fill">
-    <mat-label>Tags</mat-label>
-    <input matInput [(ngModel)]="data.objective.tags">
-  </mat-form-field>
-  <mat-form-field appearance="fill">
-    <mat-label>Notes</mat-label>
-    <textarea matInput [(ngModel)]="data.objective.notes" rows="3"></textarea>
-  </mat-form-field>
-  <div class="flex">
-    <mat-checkbox class="margin-right-8"
-        [(ngModel)]="data.objective.displayOptions.enableMarkdown">
-      Enable Markdown
-    </mat-checkbox>
-    <a mat-icon-button
-        href="https://guides.github.com/features/mastering-markdown/#examples"
-        target="_blank"
-        rel="noopener noreferrer">
-      <mat-icon>help_outline</mat-icon>
-    </a>
-  </div>
+  <fieldset>
+    <mat-form-field appearance="fill">
+      <mat-label>Commitment type</mat-label>
+      <mat-select [(ngModel)]="data.objective.commitmentType">
+          <mat-option value="Aspirational">Aspirational</mat-option>
+          <mat-option value="Committed">Committed</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field hintLabel="({{data.unit}})" appearance="fill">
+      <mat-label>Resource estimate</mat-label>
+      <input matInput [(ngModel)]="data.objective.resourceEstimate" type="number">
+    </mat-form-field>
+    <mat-form-field hintLabel="(key1:value1,key2:value2,...)" appearance="fill">
+      <mat-label>Groups</mat-label>
+      <input matInput [(ngModel)]="data.objective.groups">
+    </mat-form-field>
+    <mat-form-field hintLabel="(Comma-separated)" appearance="fill">
+      <mat-label>Tags</mat-label>
+      <input matInput [(ngModel)]="data.objective.tags">
+    </mat-form-field>
+  </fieldset>
+  <fieldset>
+    <mat-form-field appearance="fill">
+      <mat-label>Notes</mat-label>
+      <textarea matInput [(ngModel)]="data.objective.notes" rows="4"></textarea>
+    </mat-form-field>
+  </fieldset>
 </div>
 
 <div mat-dialog-actions>

--- a/src/app/edit-objective-dialog/edit-objective-dialog.component.ts
+++ b/src/app/edit-objective-dialog/edit-objective-dialog.component.ts
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Component, OnInit, Inject, EventEmitter } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Inject,
+  OnInit,
+  ViewEncapsulation,
+} from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import {
   CommitmentType,
@@ -114,6 +120,7 @@ const makeObjective = (edited: EditedObjective): ImmutableObjective =>
   selector: 'app-edit-objective-dialog',
   templateUrl: './edit-objective-dialog.component.html',
   styleUrls: ['./edit-objective-dialog.component.css'],
+  encapsulation: ViewEncapsulation.None,
 })
 export class EditObjectiveDialogComponent implements OnInit {
   constructor(

--- a/src/app/material/material.module.ts
+++ b/src/app/material/material.module.ts
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
+import {
+  MAT_FORM_FIELD_DEFAULT_OPTIONS,
+  MatFormFieldModule,
+} from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
@@ -29,13 +32,31 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  MAT_SNACK_BAR_DEFAULT_OPTIONS,
+  MatSnackBarModule,
+} from '@angular/material/snack-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
+  providers: [
+    {
+      // For accessibility reasons, it is good practice to float the labels when
+      // text is not present because in the non-floated state, they look similar
+      // to placeholders. And placeholders in general don't look drastically
+      // different than input text, and so it's harder to quickly identify empty
+      // form fields.
+      provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
+      useValue: { floatLabel: 'always' },
+    },
+    {
+      provide: MAT_SNACK_BAR_DEFAULT_OPTIONS,
+      useValue: { duration: 2500 },
+    },
+  ],
   declarations: [],
   imports: [
     CommonModule,

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,10 +8,6 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
-.flex {
-  display: flex;
-}
-
 .error {
   color: #dc3545;
 }
@@ -35,8 +31,4 @@ body {
 .mat-card-actions .mat-button-base,
 .mat-dialog-actions .mat-button-base {
   text-transform: uppercase;
-}
-
-.margin-right-8 {
-  margin-right: 8px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,9 +1,25 @@
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+}
+
+.flex {
+  display: flex;
+}
+
 .error {
   color: #dc3545;
 }
+
 .warning {
   color: darkorange;
 }
+
 .overallocated {
   color: darkorange;
 }
@@ -11,6 +27,7 @@
 .grid-container {
   margin: 20px;
 }
+
 .mat-card-header-text {
   width: 100%;
 }
@@ -20,11 +37,6 @@
   text-transform: uppercase;
 }
 
-html,
-body {
-  height: 100%;
-}
-body {
-  margin: 0;
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
+.margin-right-8 {
+  margin-right: 8px;
 }


### PR DESCRIPTION
- Increase form fields to 320px
- Move hints out of `<mat-label>` and into `hintLabel`
- Move help link out of `<mat-checkbox>` to fix focus
- Fix alignment and centering of checkbox, label, and icon