### PR TITLE
Update reordering CSS and expand clickable area for objectives

### DIFF
--- a/src/app/bucket/bucket.component.css
+++ b/src/app/bucket/bucket.component.css
@@ -1,3 +1,7 @@
+app-bucket {
+  --color: rgba(0, 0, 0, 0.04);
+}
+
 app-bucket .header-button {
   float: right;
 }
@@ -10,7 +14,12 @@ app-bucket .mat-icon-button {
   width: 30px;
 }
 
-app-bucket .cdk-drop-list-dragging mat-list-item {
+app-bucket .interactive:hover {
+  background-color: var(--color);
+  cursor: pointer;
+}
+
+app-bucket .cdk-drop-list-dragging .interactive {
   background-color: #fff;
   cursor: move;
 }
@@ -20,7 +29,7 @@ app-bucket .mat-list-item-content {
 }
 
 app-bucket .cdk-drag-placeholder {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: var(--color);
   cursor: move;
   min-height: 40px;
   transition: var(--transition); /* From <body> */

--- a/src/app/bucket/bucket.component.css
+++ b/src/app/bucket/bucket.component.css
@@ -1,22 +1,53 @@
-.header-button {
+app-bucket .header-button {
   float: right;
 }
-.order-buttons {
+
+app-bucket .order-buttons {
   margin-right: 10px;
 }
-.mat-icon-button {
+
+app-bucket .mat-icon-button {
   width: 30px;
 }
-.reorder-icon {
-  vertical-align: middle;
-  padding-right: 10px;
-  padding-bottom: 15px;
+
+app-bucket .cdk-drop-list-dragging mat-list-item {
+  background-color: #fff;
+  cursor: move;
 }
-.app-mat-list .mat-list-item {
-  height: auto;
+
+app-bucket .mat-list-item-content {
+  display: flex;
+}
+
+app-bucket .cdk-drag-placeholder {
+  background-color: rgba(0, 0, 0, 0.04);
+  cursor: move;
   min-height: 40px;
+  transition: var(--transition); /* From <body> */
 }
-.mat-list-item app-objective {
-  padding-bottom: 15px;
+
+app-bucket .cdk-drag-handle,
+.cdk-drag-preview-app-bucket .cdk-drag-handle {
+  color: #616161;
+  cursor: move;
+  padding-right: 8px;
+}
+
+app-bucket app-objective,
+.cdk-drag-preview-app-bucket app-objective {
   width: 100%;
+}
+
+/* These elements exist in the global scope and not within <app-bucket> */
+.cdk-drag-preview-app-bucket {
+  background-color: #fff;
+  display: flex;
+  font-size: 12px;
+}
+
+.cdk-drag-preview-app-bucket .mat-list-item-content {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  padding: 0 16px;
 }

--- a/src/app/bucket/bucket.component.html
+++ b/src/app/bucket/bucket.component.html
@@ -21,13 +21,17 @@
 </mat-card-header>
 <mat-card-content>
 <mat-list dense *ngIf="!showOrderButtons">
-  <mat-list-item *ngFor="let displayObjective of bucket!.objectives | displayObjectives">
+  <mat-list-item *ngFor="let displayObjective of objectives; index as i"
+      [class.interactive]="isEditingEnabled"
+      [attr.data-key]="i">
     <ng-container *ngTemplateOutlet="objective; context: {$implicit: displayObjective}">
     </ng-container>
   </mat-list-item>
 </mat-list>
 <mat-list dense *ngIf="showOrderButtons" cdkDropList (cdkDropListDropped)="reorderDrop($event)">
-  <mat-list-item *ngFor="let displayObjective of bucket!.objectives | displayObjectives"
+  <mat-list-item *ngFor="let displayObjective of objectives; index as i"
+      [class.interactive]="isEditingEnabled"
+      [attr.data-key]="i"
       cdkDrag
       [cdkDragPreviewClass]="['cdk-drag-preview-app-bucket', 'mat-elevation-z1']">
     <div *cdkDragPlaceholder></div>
@@ -44,14 +48,10 @@
   <app-objective
       [objective]="displayObjective.objective"
       [unit]="unit"
-      [unallocatedTime]="unallocatedTime"
       [isEditingEnabled]="isEditingEnabled"
-      [isReorderingEnabled]="showOrderButtons"
-      [otherBuckets]="otherBuckets"
+      [assignActionClass]="assignActionClass"
+      [isAssignButtonEnabled]="enableAssignButton(displayObjective.objective)"
       [resourcesCumulativeSum]="displayObjective.cumulativeSum"
-      [bucketAllocationLimit]="bucketAllocationLimit()"
-      (moveBucket)="moveObjective($event[0], $event[1], $event[2])"
-      (delete)="deleteObjective($event)"
-      (changed)="onObjectiveChanged($event[0], $event[1])">
+      [bucketAllocationLimit]="bucketAllocationLimit()">
   </app-objective>
 </ng-template>

--- a/src/app/bucket/bucket.component.html
+++ b/src/app/bucket/bucket.component.html
@@ -20,36 +20,38 @@
 </mat-card-subtitle>
 </mat-card-header>
 <mat-card-content>
-<mat-list dense *ngIf="!showOrderButtons" class="app-mat-list">
-    <mat-list-item *ngFor="let displayObjective of bucket!.objectives | displayObjectives ">
-    <app-objective
-        [objective]="displayObjective.objective" [unit]="unit"
-        [unallocatedTime]="unallocatedTime"
-        [isEditingEnabled]="isEditingEnabled"
-        [isReorderingEnabled]="showOrderButtons"
-        [otherBuckets]="otherBuckets"
-        [resourcesCumulativeSum]="displayObjective.cumulativeSum"
-        [bucketAllocationLimit]="bucketAllocationLimit()"
-        (moveBucket)="moveObjective($event[0], $event[1], $event[2])"
-        (delete)="deleteObjective($event)"
-        (changed)="onObjectiveChanged($event[0], $event[1])"></app-objective>
-    </mat-list-item>
+<mat-list dense *ngIf="!showOrderButtons">
+  <mat-list-item *ngFor="let displayObjective of bucket!.objectives | displayObjectives">
+    <ng-container *ngTemplateOutlet="objective; context: {$implicit: displayObjective}">
+    </ng-container>
+  </mat-list-item>
 </mat-list>
-<mat-list dense *ngIf="showOrderButtons" cdkDropList (cdkDropListDropped)="reorderDrop($event)" class="app-mat-list">
-    <mat-list-item *ngFor="let displayObjective of bucket!.objectives | displayObjectives" cdkDrag>
-        <i class="material-icons reorder-icon" cdkDragHandle>reorder</i>
-        <app-objective
-            [objective]="displayObjective.objective" [unit]="unit"
-            [unallocatedTime]="unallocatedTime"
-            [isEditingEnabled]="isEditingEnabled"
-            [isReorderingEnabled]="showOrderButtons"
-            [otherBuckets]="otherBuckets"
-            [resourcesCumulativeSum]="displayObjective.cumulativeSum"
-            [bucketAllocationLimit]="bucketAllocationLimit()"
-            (moveBucket)="moveObjective($event[0], $event[1], $event[2])"
-            (delete)="deleteObjective($event)"
-            (changed)="onObjectiveChanged($event[0], $event[1])"></app-objective>
-    </mat-list-item>
+<mat-list dense *ngIf="showOrderButtons" cdkDropList (cdkDropListDropped)="reorderDrop($event)">
+  <mat-list-item *ngFor="let displayObjective of bucket!.objectives | displayObjectives"
+      cdkDrag
+      [cdkDragPreviewClass]="['cdk-drag-preview-app-bucket', 'mat-elevation-z1']">
+    <div *cdkDragPlaceholder></div>
+    <i class="material-icons" cdkDragHandle>reorder</i>
+    <ng-container *ngTemplateOutlet="objective; context: {$implicit: displayObjective}">
+    </ng-container>
+  </mat-list-item>
 </mat-list>
 </mat-card-content>
 </mat-card>
+
+<!-- Reusable template for <app-objective> -->
+<ng-template #objective let-displayObjective>
+  <app-objective
+      [objective]="displayObjective.objective"
+      [unit]="unit"
+      [unallocatedTime]="unallocatedTime"
+      [isEditingEnabled]="isEditingEnabled"
+      [isReorderingEnabled]="showOrderButtons"
+      [otherBuckets]="otherBuckets"
+      [resourcesCumulativeSum]="displayObjective.cumulativeSum"
+      [bucketAllocationLimit]="bucketAllocationLimit()"
+      (moveBucket)="moveObjective($event[0], $event[1], $event[2])"
+      (delete)="deleteObjective($event)"
+      (changed)="onObjectiveChanged($event[0], $event[1])">
+  </app-objective>
+</ng-template>

--- a/src/app/bucket/bucket.component.spec.ts
+++ b/src/app/bucket/bucket.component.spec.ts
@@ -14,12 +14,40 @@
 
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
-import { BucketComponent } from './bucket.component';
+import { BucketComponent, personAssignmentData } from './bucket.component';
 import { FormsModule } from '@angular/forms';
+import { Assignment } from '../assignment';
 import { Bucket, ImmutableBucket } from '../bucket';
+import { CommitmentType, ImmutableObjective } from '../objective';
 import { ObjectiveComponent } from '../objective/objective.component';
 import { MaterialModule } from '../material/material.module';
 import { DisplayObjectivesPipe } from './displayobjectives.pipe';
+
+const DEFAULT_ASSIGNMENTS: Assignment[] = [
+  { personId: 'alice', commitment: 1 },
+  { personId: 'bob', commitment: 2 },
+];
+
+const DEFAULT_UNALLOCATED_TIME: ReadonlyMap<string, number> = new Map([
+  ['alice', -1],
+  ['bob', 0],
+  ['charlie', 3],
+  ['dave', 0],
+]);
+
+export const makeObjective = (
+  resourceEstimate: number,
+  assignments: Assignment[] = DEFAULT_ASSIGNMENTS
+): ImmutableObjective =>
+  ImmutableObjective.fromObjective({
+    resourceEstimate,
+    assignments,
+    name: 'test objective',
+    commitmentType: CommitmentType.Aspirational,
+    groups: [],
+    tags: [],
+    notes: '',
+  });
 
 describe('BucketComponent', () => {
   let component: BucketComponent;
@@ -46,11 +74,41 @@ describe('BucketComponent', () => {
       component.bucket = ImmutableBucket.fromBucket(
         new Bucket('test bucket', 100, [])
       );
+      component.unallocatedTime = DEFAULT_UNALLOCATED_TIME;
+      component.isEditingEnabled = true;
       fixture.detectChanges();
     })
   );
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should generate correct assignment data', () => {
+    const assignmentData = personAssignmentData(
+      DEFAULT_UNALLOCATED_TIME,
+      makeObjective(6, DEFAULT_ASSIGNMENTS).assignments
+    );
+    expect(assignmentData.filter((d) => d.username === 'bob')).toEqual([
+      { username: 'bob', available: 2, assign: 2 },
+    ]);
+    expect(assignmentData.filter((d) => d.username === 'charlie')).toEqual([
+      { username: 'charlie', available: 3, assign: 0 },
+    ]);
+    expect(assignmentData.filter((d) => d.username === 'alice')).toEqual([
+      { username: 'alice', available: 0, assign: 1 },
+    ]);
+    expect(assignmentData.filter((d) => d.username === 'dave')).toEqual([]);
+  });
+
+  it('should enable assign button if there are assignments but estimate = 0', () => {
+    const objective = makeObjective(0);
+    expect(component.enableAssignButton(objective)).toEqual(true);
+  });
+
+  it('should enable assign button if there is an estimate but no assignments', () => {
+    const objective = makeObjective(6, []);
+    expect(component.enableAssignButton(objective)).toEqual(true);
+  });
+
+  it('should not enable assign button if estimate = 0 and there are no assignments', () => {
+    const objective = makeObjective(0, []);
+    expect(component.enableAssignButton(objective)).toEqual(false);
   });
 });

--- a/src/app/bucket/bucket.component.ts
+++ b/src/app/bucket/bucket.component.ts
@@ -12,38 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   Input,
-  OnInit,
+  OnChanges,
+  OnDestroy,
   Output,
+  SimpleChanges,
+  ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
-import { Bucket, ImmutableBucket } from '../bucket';
-import { CommitmentType, ImmutableObjective } from '../objective';
+import { MatCard } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
+import { fromEvent, ReplaySubject } from 'rxjs';
+import { filter, map, take, takeUntil } from 'rxjs/operators';
+import {
+  PersonAssignmentData,
+  AssignmentDialogComponent,
+  AssignmentDialogData,
+} from '../assignment-dialog/assignment-dialog.component';
+import { Bucket, ImmutableBucket } from '../bucket';
 import {
   EditObjectiveDialogComponent,
   EditObjectiveDialogData,
+  makeEditedObjective,
 } from '../edit-objective-dialog/edit-objective-dialog.component';
 import {
   EditBucketDialogComponent,
   EditBucketDialogData,
 } from '../edit-bucket-dialog/edit-bucket-dialog.component';
-import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
+import { CommitmentType, ImmutableObjective } from '../objective';
 import { ObjectiveComponent } from '../objective/objective.component';
+import { DisplayObjectivesPipe } from './displayobjectives.pipe';
+import { Assignment, ImmutableAssignment } from '../assignment';
 
 @Component({
   selector: 'app-bucket',
   templateUrl: './bucket.component.html',
   styleUrls: ['./bucket.component.css'],
+  providers: [DisplayObjectivesPipe],
   // Requires all inputs to be immutable
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class BucketComponent implements OnInit {
+export class BucketComponent implements AfterViewInit, OnChanges, OnDestroy {
   @Input() bucket?: ImmutableBucket;
   @Input() unit?: string;
   @Input() totalAllocationPercentage?: number;
@@ -53,6 +71,7 @@ export class BucketComponent implements OnInit {
   @Input() showOrderButtons?: boolean;
   @Input() isEditingEnabled?: boolean;
   @Input() otherBuckets?: readonly ImmutableBucket[];
+
   @Output() moveBucketUp = new EventEmitter<ImmutableBucket>();
   @Output() moveBucketDown = new EventEmitter<ImmutableBucket>();
   @Output() moveObjectiveBucket = new EventEmitter<
@@ -61,9 +80,78 @@ export class BucketComponent implements OnInit {
   @Output() changed = new EventEmitter<[ImmutableBucket, ImmutableBucket]>();
   @Output() delete = new EventEmitter<ImmutableBucket>();
 
-  constructor(public dialog: MatDialog) {}
+  @ViewChild(MatCard, { read: ElementRef })
+  private readonly card?: ElementRef<HTMLElement>;
 
-  ngOnInit(): void {}
+  /** The CSS class used for targeting assign actions */
+  readonly assignActionClass = 'assign-action';
+
+  /** The objectives to show in the bucket */
+  objectives: DisplayObjective[] = [];
+
+  /** Observable to help with unsubscribing when this component is destroyed */
+  private readonly destroyed$ = new ReplaySubject<void>(1);
+
+  constructor(
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly displayObjectives: DisplayObjectivesPipe,
+    private readonly dialog: MatDialog
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.bucket) {
+      const objectives = this.bucket?.objectives || [];
+      this.objectives = this.displayObjectives.transform(objectives);
+
+      // Since we're using OnPush, it's good practice to let Angular's change
+      // detector know to check for changes since `this.objectives` has changed
+      this.changeDetectorRef.markForCheck();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    // Use event delegation to have a single click listener for all clicks. This
+    // listener will handle events from both the assign action and objective
+    // clicks. This will stop listening once the component is destroyed.
+    fromEvent<MouseEvent>(this.card!.nativeElement, 'click', { passive: true })
+      .pipe(
+        takeUntil(this.destroyed$),
+        map(({ target }) => target),
+        filter((t): t is HTMLElement => t instanceof HTMLElement)
+      )
+      .subscribe((target) => {
+        // Find the index of the objective that was clicked. If an index is not
+        // found, that means the click happened outside of what we're interested
+        // in.
+        const dataKey = target.closest<HTMLElement>('[data-key]');
+        const keyStr = dataKey instanceof HTMLElement && dataKey.dataset.key;
+        const key = keyStr ? Number(keyStr) : Number.NaN;
+        if (Number.isNaN(key)) {
+          return;
+        }
+
+        const objective = this.objectives[key];
+        if (!objective) {
+          throw new Error(`Could not get objective ${key} from objectives`);
+        }
+
+        // Check if this click was on the assign button or the objective. We
+        // need to check this first, since the assign target is a child of the
+        // objective.
+        const assign = target.closest(`.${this.assignActionClass}`);
+        if (assign) {
+          this.assign(objective.objective);
+          return;
+        }
+
+        this.editObjective(objective.objective);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroyed$.next();
+    this.destroyed$.complete();
+  }
 
   /**
    * Limit of resources expected to be allocated to the given bucket in this period,
@@ -95,6 +183,39 @@ export class BucketComponent implements OnInit {
         this.changed.emit([this.bucket!, ImmutableBucket.fromBucket(bucket)]);
       }
     });
+  }
+
+  private editObjective(objective: ImmutableObjective): void {
+    if (!this.isEditingEnabled) {
+      return;
+    }
+
+    const dialogRef = this.dialog.open(EditObjectiveDialogComponent, {
+      data: {
+        objective: makeEditedObjective(objective),
+        original: objective,
+        title: 'Edit Objective',
+        okAction: 'OK',
+        unit: this.unit || '',
+        otherBuckets: this.otherBuckets || [],
+        onMoveBucket: this.moveObjective,
+        onDelete: this.deleteObjective,
+      } as EditObjectiveDialogData,
+    });
+
+    // Listen for events when the dialog is closed. Unsubscribe the listener
+    // when this component is either destroyed or when the close action has
+    // emitted once.
+    dialogRef
+      .afterClosed()
+      .pipe(
+        takeUntil(this.destroyed$),
+        take(1),
+        filter((obj): obj is ImmutableObjective => !!obj)
+      )
+      .subscribe((newObjective) => {
+        this.onObjectiveChanged(objective, newObjective);
+      });
   }
 
   addObjective(): void {
@@ -156,6 +277,67 @@ export class BucketComponent implements OnInit {
     ]);
   }
 
+  private assign(objective: ImmutableObjective): void {
+    if (!this.enableAssignButton(objective)) {
+      return;
+    }
+
+    const unallocatedTime = this.unallocatedTime;
+    if (!unallocatedTime) {
+      throw new Error('Expected unallocatedTime to be defined');
+    }
+
+    const dialogRef = this.dialog.open(AssignmentDialogComponent, {
+      width: '700px',
+      data: {
+        objective: objective.toOriginal(),
+        people: personAssignmentData(unallocatedTime, objective.assignments),
+        unit: this.unit || '',
+        columns: ['person', 'available', 'assign', 'actions'],
+      } as AssignmentDialogData,
+    });
+
+    dialogRef
+      .afterClosed()
+      .pipe(
+        takeUntil(this.destroyed$),
+        take(1),
+        filter((result): result is AssignmentDialogData => !!result)
+      )
+      .subscribe((result) => {
+        const newAssignments = result.people.reduce(
+          (assignments: ImmutableAssignment[], { assign, username }) => {
+            if (assign > 0) {
+              assignments.push(
+                new ImmutableAssignment(new Assignment(username, assign))
+              );
+            }
+
+            return assignments;
+          },
+          []
+        );
+
+        const newObjective = objective.withAssignments(newAssignments);
+        this.onObjectiveChanged(objective, newObjective);
+      });
+  }
+
+  enableAssignButton(objective: ImmutableObjective): boolean {
+    return (
+      !!this.isEditingEnabled &&
+      (objective.resourceEstimate > 0 || objective.assignments.length > 0) &&
+      this.hasPeopleAvailable(objective)
+    );
+  }
+
+  private hasPeopleAvailable(objective: ImmutableObjective): boolean {
+    return (
+      objective.assignments.some((a) => a.commitment > 0) ||
+      [...this.unallocatedTime!.values()].some((t) => t > 0)
+    );
+  }
+
   reorderDrop(event: CdkDragDrop<ObjectiveComponent[]>): void {
     const newObjectives = [...this.bucket!.objectives];
     moveItemInArray(newObjectives, event.previousIndex, event.currentIndex);
@@ -214,3 +396,32 @@ export interface DisplayObjective {
   objective: ImmutableObjective;
   cumulativeSum: number;
 }
+
+export const personAssignmentData = (
+  unallocatedTime: ReadonlyMap<string, number>,
+  assignments: readonly ImmutableAssignment[]
+): PersonAssignmentData[] =>
+  [...unallocatedTime.entries()].reduce(
+    (data: PersonAssignmentData[], [personId, unallocated]) => {
+      const assign = currentAssignment(assignments, personId);
+      if (unallocated > 0 || assign > 0) {
+        data.push({
+          assign,
+          username: personId,
+          available: unallocated + assign,
+        });
+      }
+
+      return data;
+    },
+    []
+  );
+
+const currentAssignment = (
+  assignments: readonly ImmutableAssignment[],
+  personId: string
+): number =>
+  assignments.reduce(
+    (sum, a) => (a.personId === personId ? sum + a.commitment : sum),
+    0
+  );

--- a/src/app/bucket/bucket.component.ts
+++ b/src/app/bucket/bucket.component.ts
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 import {
-  Component,
-  OnInit,
-  Input,
-  Output,
-  EventEmitter,
   ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewEncapsulation,
 } from '@angular/core';
 import { Bucket, ImmutableBucket } from '../bucket';
 import { CommitmentType, ImmutableObjective } from '../objective';
@@ -40,6 +41,7 @@ import { ObjectiveComponent } from '../objective/objective.component';
   styleUrls: ['./bucket.component.css'],
   // Requires all inputs to be immutable
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
 })
 export class BucketComponent implements OnInit {
   @Input() bucket?: ImmutableBucket;

--- a/src/app/edit-objective-dialog/edit-objective-dialog.component.ts
+++ b/src/app/edit-objective-dialog/edit-objective-dialog.component.ts
@@ -48,10 +48,12 @@ export interface EditObjectiveDialogData {
   okAction: string;
   unit: string;
   otherBuckets: readonly ImmutableBucket[];
-  onMoveBucket?: EventEmitter<
-    [ImmutableObjective, ImmutableObjective, ImmutableBucket]
-  >;
-  onDelete?: EventEmitter<ImmutableObjective>;
+  onMoveBucket?: (
+    original: ImmutableObjective,
+    newObjective: ImmutableObjective,
+    newBucket: ImmutableBucket
+  ) => void;
+  onDelete?: (objective: ImmutableObjective) => void;
 }
 
 export const makeEditedObjective = (
@@ -147,12 +149,16 @@ export class EditObjectiveDialogComponent implements OnInit {
   }
 
   onMove(newBucket: ImmutableBucket): void {
+    if (!this.data.original) {
+      throw new Error('Original objective not found');
+    }
+
+    if (!this.data.onMoveBucket) {
+      throw new Error('Expected onMoveBucket callback');
+    }
+
     const newObjective = makeObjective(this.data.objective);
-    this.data.onMoveBucket!.emit([
-      this.data.original!,
-      newObjective,
-      newBucket,
-    ]);
+    this.data.onMoveBucket(this.data.original, newObjective, newBucket);
     this.dialogRef.close();
   }
 
@@ -161,7 +167,15 @@ export class EditObjectiveDialogComponent implements OnInit {
   }
 
   onConfirmDelete(): void {
-    this.data.onDelete!.emit(this.data.original);
+    if (!this.data.original) {
+      throw new Error('Original objective not found');
+    }
+
+    if (!this.data.onDelete) {
+      throw new Error('Expected onDelete callback');
+    }
+
+    this.data.onDelete(this.data.original);
     this.dialogRef.close();
   }
 

--- a/src/app/objective/objective.component.css
+++ b/src/app/objective/objective.component.css
@@ -15,6 +15,12 @@
   margin-left: 10px;
   font-weight: bold;
 }
+.assignments-text {
+  white-space: nowrap;
+}
+.assignments-text:hover {
+  text-decoration: underline;
+}
 .unassigned {
   color: grey;
 }

--- a/src/app/objective/objective.component.html
+++ b/src/app/objective/objective.component.html
@@ -1,19 +1,44 @@
 <div class="objective-all">
 <div class="objective">
-<span (click)="edit()" [class.unassigned]="!objective?.assignments?.length">
-    <app-pill *ngIf="isCommitted()">C</app-pill><span *ngIf="objective?.displayOptions?.enableMarkdown" [innerHTML]="objective?.name | markdownify: (isEditingEnabled ? 'nolinks' : '')"></span><span *ngIf="!objective?.displayOptions?.enableMarkdown">{{objective?.name}}</span>
-    <span class="resource-estimate"> ({{objective?.resourceEstimate}} {{unit}})</span>
+<span [class.unassigned]="!objective?.assignments?.length">
+  <app-pill *ngIf="isCommitted()">C</app-pill>
+  <span *ngIf="objective?.displayOptions?.enableMarkdown"
+      [innerHTML]="objective?.name | markdownify: (isEditingEnabled ? 'nolinks' : '')">
+  </span>
+  <span *ngIf="!objective?.displayOptions?.enableMarkdown">
+    {{objective?.name}}
+  </span>
+  <span class="resource-estimate">({{objective?.resourceEstimate}} {{unit}})</span>
 </span>
-<span *ngIf="objective?.notes" class="icons"><i (click)="edit()" matTooltip="{{objective?.notes}}" matTooltipShowDelay="200" matTooltipHideDelay="2000" class="material-icons notes-icon">note</i></span>
-<span (click)="assign()" class="assignments"
-    [class.fully-allocated]="isFullyAllocated() && !isOverAllocated()"
-    [class.warning]="!isFullyAllocated()"
-    [class.error]="isOverAllocated()"><span *ngFor="let assignment of objective?.assignments | assignSummParts; last as isLast" style="white-space: nowrap">{{assignment}}<span *ngIf="!isLast">, </span></span></span>
-<span *ngIf="showAssignButton()" class="assign-button"
-    [class.assign-button-enabled]="enableAssignButton()"
-    [class.assign-button-disabled]="!enableAssignButton()"><a (click)="assign()">Assign</a></span>
+<span *ngIf="objective?.notes" class="icons">
+  <i class="material-icons notes-icon"
+      matTooltip="{{objective?.notes}}"
+      matTooltipShowDelay="200"
+      matTooltipHideDelay="2000">
+    note
+  </i>
+</span>
+<span class="{{assignActionClass}}">
+  <span class="assignments"
+      [class.fully-allocated]="isFullyAllocated() && !isOverAllocated()"
+      [class.warning]="!isFullyAllocated()"
+      [class.error]="isOverAllocated()">
+    <span class="assignments-text">
+      {{(objective?.assignments | assignSummParts).join(', ')}}
+    </span>
+  </span>
+  <span *ngIf="showAssignButton()"
+      class="assign-button"
+      [class.assign-button-enabled]="isAssignButtonEnabled"
+      [class.assign-button-disabled]="!isAssignButtonEnabled">
+    <a>Assign</a>
+  </span>
+</span>
 </div>
-<div *ngIf="resourcesCumulativeSum !== undefined && bucketAllocationLimit !== undefined && objective?.resourceEstimate !== undefined" class="resource-csum">
-    <span [ngClass]="resourcesCumulativeSum | csumClass: bucketAllocationLimit: objective?.resourceEstimate!">{{resourcesCumulativeSum}}</span>
+<div *ngIf="resourcesCumulativeSum !== undefined && bucketAllocationLimit !== undefined && objective?.resourceEstimate !== undefined"
+    class="resource-csum">
+  <span [ngClass]="resourcesCumulativeSum | csumClass: bucketAllocationLimit: objective?.resourceEstimate!">
+    {{resourcesCumulativeSum}}
+  </span>
 </div>
 </div>

--- a/src/app/objective/objective.component.spec.ts
+++ b/src/app/objective/objective.component.spec.ts
@@ -16,15 +16,9 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ObjectiveComponent } from './objective.component';
 import { FormsModule } from '@angular/forms';
-import { CommitmentType, ImmutableObjective } from '../objective';
+import { makeObjective } from '../bucket/bucket.component.spec';
 import { MaterialModule } from '../material/material.module';
-import { Assignment } from '../assignment';
 import { AssignSummPartsPipe } from './assign-summ-parts.pipe';
-
-const DEFAULT_ASSIGNMENTS: Assignment[] = [
-  { personId: 'alice', commitment: 1 },
-  { personId: 'bob', commitment: 2 },
-];
 
 describe('ObjectiveComponent', () => {
   let component: ObjectiveComponent;
@@ -39,69 +33,16 @@ describe('ObjectiveComponent', () => {
     })
   );
 
-  const makeComponent = (
-    resourceEstimate: number,
-    assignments: Assignment[]
-  ): ObjectiveComponent => {
-    const result = fixture.componentInstance;
-    result.objective = ImmutableObjective.fromObjective({
-      name: 'test objective',
-      resourceEstimate,
-      commitmentType: CommitmentType.Aspirational,
-      groups: [],
-      tags: [],
-      notes: '',
-      assignments,
-    });
-    result.unit = 'person weeks';
-    const unallocatedTime = new Map();
-    unallocatedTime.set('alice', -1); // Temporary over-allocation for alice
-    unallocatedTime.set('bob', 0);
-    unallocatedTime.set('charlie', 3);
-    unallocatedTime.set('dave', 0);
-    result.unallocatedTime = unallocatedTime;
-    result.isEditingEnabled = true;
-    return result;
-  };
-
   beforeEach(
     waitForAsync(() => {
       fixture = TestBed.createComponent(ObjectiveComponent);
-      component = makeComponent(6, DEFAULT_ASSIGNMENTS);
+      component = fixture.componentInstance;
+      component.objective = makeObjective(6);
       fixture.detectChanges();
     })
   );
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should generate correct assignment data', () => {
-    const assignmentData = component.personAssignmentData();
-    expect(assignmentData.filter((d) => d.username === 'bob')).toEqual([
-      { username: 'bob', available: 2, assign: 2 },
-    ]);
-    expect(assignmentData.filter((d) => d.username === 'charlie')).toEqual([
-      { username: 'charlie', available: 3, assign: 0 },
-    ]);
-    expect(assignmentData.filter((d) => d.username === 'alice')).toEqual([
-      { username: 'alice', available: 0, assign: 1 },
-    ]);
-    expect(assignmentData.filter((d) => d.username === 'dave')).toEqual([]);
-  });
-
-  it('should enable assign button if there are assignments but estimate = 0', () => {
-    component = makeComponent(0, DEFAULT_ASSIGNMENTS);
-    expect(component.enableAssignButton()).toEqual(true);
-  });
-
-  it('should enable assign button if there is an estimate but no assignments', () => {
-    component = makeComponent(6, []);
-    expect(component.enableAssignButton()).toEqual(true);
-  });
-
-  it('should not enable assign button if estimate = 0 and there are no assignments', () => {
-    component = makeComponent(0, []);
-    expect(component.enableAssignButton()).toEqual(false);
   });
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,8 +4,12 @@ body {
 }
 
 body {
-  margin: 0;
+  --transition: transform 200ms cubic-bezier(0, 0, 0.2, 1);
   font-family: Roboto, 'Helvetica Neue', sans-serif;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
+  text-rendering: optimizeLegibility;
 }
 
 .error {
@@ -31,4 +35,9 @@ body {
 .mat-card-actions .mat-button-base,
 .mat-dialog-actions .mat-button-base {
   text-transform: uppercase;
+}
+
+.cdk-drag-animating,
+.cdk-drop-list-dragging .cdk-drag {
+  transition: var(--transition);
 }


### PR DESCRIPTION
Bucket: Update reordering style and animation
- Make list items more readable while dragging
- Show placeholder where list item will be dragged to
- Keep consistent styling between dragged and static items

Expand clickable area for objectives
- Refactor click logic to use event delegation, single listener for all clicks
- Reduce passing excessive state down from Bucket to Objective
- Add unsubscribe hooks for dialog close states
- Show grey background hover effect and pointer cursor to indicate clickable area
- Show underline on assignees' names to indicate clickability