### PR TITLE
Make it easier to bring bucket percent totals to 100 (#230)

### DIFF
--- a/src/app/bucket/bucket.component.html
+++ b/src/app/bucket/bucket.component.html
@@ -6,7 +6,7 @@
         <button (click)="onMoveBucketDown()" mat-icon-button color="primary"><mat-icon>arrow_downward</mat-icon></button>
     </span>
     <span (click)="edit()">{{bucket?.displayName}}
-    <span [class.error]="isOverAllocated()"> ({{bucket?.allocationPercentage}}%)</span>
+    <span [class.error]="isOverOrUnderAllocated()"> ({{bucket?.allocationPercentage}}%)</span>
     </span>
     <button (click)="addObjective()" mat-button [disabled]="!isEditingEnabled" color="primary" class="header-button">Add Objective</button>
 </mat-card-title>

--- a/src/app/bucket/bucket.component.ts
+++ b/src/app/bucket/bucket.component.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,6 +94,8 @@ export class BucketComponent {
       okAction: 'OK',
       allowCancel: false,
       title: 'Edit bucket "' + this.bucket!.displayName + '"',
+      otherBucketsTotalAllocPct:
+        this.totalAllocationPercentage! - this.bucket!.allocationPercentage,
       onDelete: this.delete,
     };
     const dialogRef = this.dialog.open(EditBucketDialogComponent, {
@@ -306,8 +308,8 @@ export class BucketComponent {
     return this.bucket!.resourcesAllocated();
   }
 
-  isOverAllocated(): boolean {
-    return this.totalAllocationPercentage! > 100;
+  isOverOrUnderAllocated(): boolean {
+    return Math.abs(this.totalAllocationPercentage! - 100) > 1e-6;
   }
 
   committedResourcesAllocated(): number {

--- a/src/app/edit-bucket-dialog/edit-bucket-dialog.component.html
+++ b/src/app/edit-bucket-dialog/edit-bucket-dialog.component.html
@@ -13,6 +13,7 @@
 
 <div mat-dialog-actions>
   <button mat-raised-button [mat-dialog-close]="data.bucket" [disabled]="!isDataValid()" color="primary">{{data.okAction}}</button>
+  <button mat-raised-button *ngIf="isAllocationUnbalanced()" (click)="balanceAllocation()">Balance</button>
   <button *ngIf="data.allowCancel" mat-button (click)="onCancel()" color="warn">Cancel</button>
   <button *ngIf="data.onDelete && !showDeleteConfirm" mat-button (click)="onDelete()" color="warn">Delete</button>
   <button *ngIf="showDeleteConfirm" mat-raised-button (click)="onCancelDelete()">Cancel Delete</button>

--- a/src/app/edit-bucket-dialog/edit-bucket-dialog.component.spec.ts
+++ b/src/app/edit-bucket-dialog/edit-bucket-dialog.component.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2019, 2021 Google LLC
+// Copyright 2019, 2021, 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ describe('EditBucketDialogComponent', () => {
     okAction: 'OK',
     allowCancel: true,
     title: 'My test dialog',
+    otherBucketsTotalAllocPct: 80,
   };
 
   beforeEach(
@@ -58,5 +59,12 @@ describe('EditBucketDialogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should balance allocations', () => {
+    expect(component.isAllocationUnbalanced()).toBeTrue();
+    component.balanceAllocation();
+    expect(component.isAllocationUnbalanced()).toBeFalse();
+    expect(component.data.bucket.allocationPercentage).toEqual(20);
   });
 });

--- a/src/app/edit-bucket-dialog/edit-bucket-dialog.component.ts
+++ b/src/app/edit-bucket-dialog/edit-bucket-dialog.component.ts
@@ -1,4 +1,4 @@
-// Copyright 2019, 2021 Google LLC
+// Copyright 2019, 2021, 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ export interface EditBucketDialogData {
   okAction: string;
   allowCancel: boolean;
   title: string;
+  otherBucketsTotalAllocPct: number;
   onDelete?: EventEmitter<ImmutableBucket>;
 }
 
@@ -60,5 +61,22 @@ export class EditBucketDialogComponent {
 
   onCancelDelete(): void {
     this.showDeleteConfirm = false;
+  }
+
+  isAllocationUnbalanced(): boolean {
+    return (
+      Math.abs(
+        this.data.bucket.allocationPercentage +
+          this.data.otherBucketsTotalAllocPct -
+          100
+      ) > 1e-6
+    );
+  }
+
+  balanceAllocation(): void {
+    this.data.bucket.allocationPercentage = Math.max(
+      0,
+      100 - this.data.otherBucketsTotalAllocPct
+    );
   }
 }

--- a/src/app/period/period.component.ts
+++ b/src/app/period/period.component.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Google LLC
+// Copyright 2019-2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -479,11 +479,13 @@ export class PeriodComponent implements OnInit {
     if (!this.isEditingEnabled) {
       return;
     }
+    const totalExistingPct = this.totalAllocationPercentage();
     const dialogData: EditBucketDialogData = {
-      bucket: new Bucket('', 0, []),
+      bucket: new Bucket('', Math.max(0, 100 - totalExistingPct), []),
       okAction: 'Add',
       allowCancel: true,
       title: 'Add bucket',
+      otherBucketsTotalAllocPct: totalExistingPct,
     };
     const dialogRef = this.dialog.open(EditBucketDialogComponent, {
       data: dialogData,


### PR DESCRIPTION
Highlight percentages in red when they total to under 100% as well as over. Default allocation percentage for new bucket to 100-existing sum. Add button to edit-bucket dialog to automatically change percentage to 100-sum.