### PR TITLE
DOM text reinterpreted as HTML Update markdownify.pipe.ts

### DIFF
--- a/src/app/markdown/markdownify.pipe.ts
+++ b/src/app/markdown/markdownify.pipe.ts
@@ -33,7 +33,7 @@ export class MarkdownifyPipe implements PipeTransform {
         if (mode === 'nolinks') {
           // Replace the link with some inert underlined text
           const el = node.ownerDocument.createElement('u');
-          el.innerHTML = node.innerHTML;
+          el.innerText = node.innerText;
           node.parentNode!.replaceChild(el, node);
         } else {
           // Make the link open in a new window

--- a/src/app/markdown/markdownify.pipe.ts
+++ b/src/app/markdown/markdownify.pipe.ts
@@ -33,7 +33,8 @@ export class MarkdownifyPipe implements PipeTransform {
         if (mode === 'nolinks') {
           // Replace the link with some inert underlined text
           const el = node.ownerDocument.createElement('u');
-          el.innerText = node.innerText;
+          (el as HTMLElement).innerText = node.innerHTML;
+
           node.parentNode!.replaceChild(el, node);
         } else {
           // Make the link open in a new window


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.