### PR TITLE
Bump golang docker to 1.19

### DIFF
--- a/docker/dev/backend/Dockerfile
+++ b/docker/dev/backend/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13
+FROM golang:1.19
 
 WORKDIR /usr/app/
 ENV GO111MODULE=on


### PR DESCRIPTION
1.13 does not run out of the box due to newer packages (excerpt output below)

```
backend   | /root/go/pkg/mod/google.golang.org/grpc@v1.59.0/stats/stats.go:77:10: undefined: any
backend   | /root/go/pkg/mod/google.golang.org/grpc@v1.59.0/stats/stats.go:147:10: undefined: any
backend   | note: module requires Go 1.19
backend   | # google.golang.org/grpc/encoding
backend   | /root/go/pkg/mod/google.golang.org/grpc@v1.59.0/encoding/encoding.go:88:12: undefined: any
backend   | /root/go/pkg/mod/google.golang.org/grpc@v1.59.0/encoding/encoding.go:90:27: undefined: any
backend   | note: module requires Go 1.19
backend   | # github.com/googleapis/enterprise-certificate-proxy/client
backend   | /root/go/pkg/mod/github.com/googleapis/enterprise-certificate-proxy@v0.3.2/client/client.go:74:12: undefined: any
backend   | /root/go/pkg/mod/github.com/googleapis/enterprise-certificate-proxy@v0.3.2/client/client.go:128:53: undefined: any
backend   | note: module requires Go 1.19
backend   | # golang.org/x/net/http2
backend   | /root/go/pkg/mod/golang.org/x/net@v0.19.0/http2/transport.go:1021:13: tc.NetConn undefined (type *tls.Conn has no field or method NetConn)
backend   | note: module requires Go 1.18
backend   | # google.golang.org/grpc/internal/pretty
backend   | /root/go/pkg/mod/google.golang.org/grpc@v1.59.0/internal/pretty/pretty.go:38:15: undefined: any
backend   | note: module requires Go 1.19
```